### PR TITLE
159 task users can set listing type and purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.4.2](https://github.com/Bankole2000/cp-backend/compare/v1.4.1...v1.4.2) (2023-01-30)
+
+
+### Bug Fixes
+
+* **listings:** update pb listings when listing type key change ([2746a1f](https://github.com/Bankole2000/cp-backend/commits/2746a1f10c4dc5664b9b48c8ba5793265b163826))
+
 ### [1.4.1](https://github.com/Bankole2000/cp-backend/compare/v1.4.0...v1.4.1) (2023-01-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.4.1](https://github.com/Bankole2000/cp-backend/compare/v1.4.0...v1.4.1) (2023-01-30)
+
+
+### Features
+
+* **listings:** users can set listing type and purpose ([9b8d628](https://github.com/Bankole2000/cp-backend/commits/9b8d6284e47154e8e9092fb84f5d521ee7a5bfde))
+
 ## [1.4.0](https://github.com/Bankole2000/cp-backend/compare/v1.3.0...v1.4.0) (2023-01-28)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "ISC",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "git add"
     ]
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "commitlint.config.js",
   "dependencies": {
     "abbrev": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "git add"
     ]
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "commitlint.config.js",
   "dependencies": {
     "abbrev": "^1.1.1",

--- a/packages/cp-listing-service/prisma/schema.prisma
+++ b/packages/cp-listing-service/prisma/schema.prisma
@@ -54,10 +54,10 @@ model Listing {
   listingPurposeSubgroup      String?
   noOfBedrooms                Int?
   noOfBathrooms               Int?
-  images                      ListingImage[]
   isPublished                 Boolean               @default(false) @db.Boolean
-  createdByData               User                  @relation(fields: [createdBy], references: [userId])
   createdBy                   String
+  createdByData               User                  @relation(fields: [createdBy], references: [userId])
+  images                      ListingImage[]
   houseRules                  ListingHasHouseRule[]
   amenities                   ListingHasAmenities[]
   listingTypeData             ListingType?          @relation("ListingType", fields: [listingType], references: [listingType])

--- a/packages/cp-listing-service/src/routes/listing.routes.ts
+++ b/packages/cp-listing-service/src/routes/listing.routes.ts
@@ -5,20 +5,22 @@ import {
   deleteListingImageHandler,
   getListingDetailsHandler,
   getListingsHandler,
-  reorderListingImagesHandler
+  reorderListingImagesHandler,
+  setListingTypeHandler
 } from '../controllers/listing.controllers';
 import { testEndpointHandler } from '../controllers/test.controllers';
 import upload from '../middleware/multerUpload';
 import { requireLoggedInUser } from '../middleware/requireUser';
 import { checkListingHasImage, checkUserOwnsListing } from '../middleware/userOwnsResource';
 import { validate } from '../middleware/validateRequests';
-import { createListingSchema } from '../schema/listing.schema';
+import { createListingSchema, setListingTypeSchema } from '../schema/listing.schema';
 
 const router = Router();
 
 router.get('/', getListingsHandler);
 router.post('/', requireLoggedInUser, validate(createListingSchema, 'Create Listing'), createListingHandler);
 router.get('/:listingId', getListingDetailsHandler);
+router.patch('/:listingId/type', requireLoggedInUser, checkUserOwnsListing, validate(setListingTypeSchema, 'Listing Type'), setListingTypeHandler);
 router.post('/:listingId/images', requireLoggedInUser, checkUserOwnsListing, upload.single('image'), addListingImageHandler);
 router.delete('/:listingId/images/:imageId', requireLoggedInUser, checkUserOwnsListing, checkListingHasImage, deleteListingImageHandler);
 router.patch('/:listingId/images/:imageId', requireLoggedInUser, checkUserOwnsListing, checkListingHasImage, reorderListingImagesHandler);

--- a/packages/cp-listing-service/src/schema/listing.schema.ts
+++ b/packages/cp-listing-service/src/schema/listing.schema.ts
@@ -2,6 +2,61 @@ import { isValidDate } from '@cribplug/common';
 import {
   object, string
 } from 'zod';
+import { db } from '../lib/lokijs';
+
+function resourceExists(collectionName: string, key: string, value: string) {
+  const collection = db.getCollection(collectionName);
+  const result = collection.findOne({ [key]: value });
+  console.log({ result });
+  return Boolean(result);
+}
+
+function subgroupBelongsToPurpose(subgroup: string, purpose: string) {
+  const sg = db.getCollection('subgroups').findOne({ purposeSubgroup: subgroup });
+  console.log({ sg });
+  return sg ? sg.listingPurpose === purpose : false;
+}
+
+export const listingTypeFieldsRequired = {
+  listingType: string({
+    required_error: ''
+  }).min(1, '')
+    .refine((val) => /^[A-Z_]+$/.test(val), 'Listing Type must be in all caps and underscore separated, e.g. LISTING_TYPE')
+    .refine((data) => resourceExists('listingTypes', 'listingType', data), 'Invalid listing type key'),
+  listingPurpose: string({
+    required_error: ''
+  }).min(1, '')
+    .refine((val) => /^[A-Z_]+$/.test(val), 'Listing purpose must be in all caps and underscore separated, e.g. LISTING_PURPOSE')
+    .refine((val) => resourceExists('purposes', 'listingPurpose', val), 'Listing purpose does not exist'),
+  listingPurposeSubgroup: string({
+    required_error: ''
+  }).min(1, '')
+    .refine((val) => /^[A-Z_]+$/.test(val), 'purpose subgroup must be in all caps and underscore separated, e.g. PURPOSE_SUBGROUP')
+    .refine((val) => resourceExists('subgroups', 'purposeSubgroup', val), 'Purpose Subgroup does not exist')
+};
+
+export const listingTypeFieldsOptional = {
+  listingType: string({}).min(1, '')
+    .refine((val) => /^[A-Z_]+$/.test(val), 'Listing Type must be in all caps and underscore separated, e.g. LISTING_TYPE')
+    .refine((data) => resourceExists('listingTypes', 'listingType', data), 'Invalid listing type key')
+    .optional(),
+  listingPurpose: string({}).min(1, '')
+    .refine((val) => /^[A-Z_]+$/.test(val), 'Listing purpose must be in all caps and underscore separated, e.g. LISTING_PURPOSE')
+    .refine((val) => resourceExists('purposes', 'listingPurpose', val), 'Listing purpose does not exist')
+    .optional(),
+  listingPurposeSubgroup: string({}).min(1, '')
+    .refine((val) => /^[A-Z_]+$/.test(val), 'purpose subgroup must be in all caps and underscore separated, e.g. PURPOSE_SUBGROUP')
+    .refine((val) => resourceExists('subgroups', 'purposeSubgroup', val), 'Purpose Subgroup does not exist')
+    .optional(),
+};
+
+const listingParam = {
+  params: object({
+    listingId: string({
+      required_error: 'Listing Id is required'
+    }).min(1, 'Listing Id must be at least 1 character long')
+  })
+};
 
 export const createListingSchema = object({
   body: object({
@@ -12,10 +67,19 @@ export const createListingSchema = object({
       required_error: 'caption is required',
     }).min(1, 'shortDescription must be at least 1 character long').max(160, 'caption must be at most 160 characters long'),
     longDescription: string({}).min(1, 'longDescription must be at least 1 character long').optional(),
-  })
+    ...listingTypeFieldsOptional
+  }).refine((data) => (data.listingPurpose || data.listingPurposeSubgroup ? subgroupBelongsToPurpose(data.listingPurposeSubgroup as string, data.listingPurpose as string) : false), 'Invalid listing purpose or subgroup')
 });
 
-export const createListingFields = ['title', 'caption', 'longDescription'];
+export const setListingTypeSchema = object({
+  ...listingParam,
+  body: object({
+    ...listingTypeFieldsRequired
+  }).refine((data) => subgroupBelongsToPurpose(data.listingPurposeSubgroup, data.listingPurpose), 'Invalid Listing purpose subgroup')
+});
+
+export const createListingFields = ['title', 'caption', 'longDescription', 'listingType', 'listingPurpose', 'listingPurposeSubgroup'];
+export const listingTypeFieldsList = ['listingType', 'listingPurpose', 'listingPurposeSubgroup'];
 
 const htmlRegex = /<\/?[^>]+(>|$)/gi;
 export const stripHTML = (html: string) => html.replace(htmlRegex, '');

--- a/packages/cp-listing-service/src/services/listing.service.ts
+++ b/packages/cp-listing-service/src/services/listing.service.ts
@@ -266,7 +266,7 @@ export default class ListingDBService {
             },
             {
               order: {
-                lte: order, 
+                lte: order,
                 gt: stop,
               }
             },

--- a/packages/cp-listing-service/src/services/listingType.service.ts
+++ b/packages/cp-listing-service/src/services/listingType.service.ts
@@ -33,6 +33,26 @@ export default class ListingTypeDBService {
     }
   }
 
+  async getListingIdsWhereType(listingType: string) {
+    try {
+      const listings = await this.prisma.listing.findMany({
+        where: {
+          listingType
+        },
+        select: {
+          listingId: true
+        }
+      });
+      if (listings.length) {
+        return new ServiceResponse('Listing Ids by type', listings, true, 200, null, null, null);
+      }
+      return new ServiceResponse('No Listing Ids by type found', null, false, 404, 'No Listing Ids found', 'No Listing Ids found', 'Check filter paramaters');
+    } catch (error: any) {
+      console.log({ error });
+      return new ServiceResponse('Error getting Listing Ids by type', null, false, 500, error.message, error, 'Check logs and database');
+    }
+  }
+
   async getListingTypeByKey(listingType: string) {
     try {
       const listingTypeData = await this.prisma.listingType.findUnique({

--- a/packages/cp-listing-service/src/services/listingType.service.ts
+++ b/packages/cp-listing-service/src/services/listingType.service.ts
@@ -63,6 +63,13 @@ export default class ListingTypeDBService {
       const newListingType = await this.prisma.listingType.create({
         data: {
           ...listingTypeData
+        },
+        include: {
+          _count: {
+            select: {
+              listings: true,
+            }
+          }
         }
       });
       if (newListingType) {
@@ -84,6 +91,13 @@ export default class ListingTypeDBService {
         },
         data: {
           ...listingTypeData
+        },
+        include: {
+          _count: {
+            select: {
+              listings: true,
+            }
+          }
         }
       });
       if (updatedListingType) {

--- a/packages/cp-listing-service/src/services/pb.service.ts
+++ b/packages/cp-listing-service/src/services/pb.service.ts
@@ -145,6 +145,13 @@ export default class PBService {
     return this.pb.authStore.isValid;
   }
 
+  async updateRecordsInParallel(collection: string, recordIds: string[], updateData: any) {
+    const promises = recordIds.map((x) => this.pb.collection(collection).update(x, updateData, {
+      $autoCancel: false,
+    }));
+    return Promise.all(promises);
+  }
+
   async createListing(listingData: any) {
     try {
       const res = await this.pb.collection('listings').create(listingData);

--- a/packages/cp-listing-service/src/services/pb.service.ts
+++ b/packages/cp-listing-service/src/services/pb.service.ts
@@ -159,6 +159,19 @@ export default class PBService {
     }
   }
 
+  async updateListing(listingId: string, listingData: any) {
+    try {
+      const res = await this.pb.collection('listings').update(listingId, listingData);
+      if (!res.code) {
+        return new ServiceResponse('Listing updated', res, true, 200, null, null, null);
+      }
+      return new ServiceResponse('Error udpating listing', res, false, 400, 'Error updating listing', 'LISTING_SERVICE_UPDATE_PB_LISTING_ERROR', 'Check inputs and logs');
+    } catch (error: any) {
+      console.log({ error });
+      return new ServiceResponse('Error updating listing', null, false, 500, error.message, error, 'Check logs and database');
+    }
+  }
+
   async getListingImages(listingId: string) {
     console.log({ listingId });
     try {

--- a/packages/cp-profile-service/src/services/user.service.ts
+++ b/packages/cp-profile-service/src/services/user.service.ts
@@ -47,7 +47,7 @@ export default class UserDBService {
     }
   }
 
-  async updateUserProfileImage(userId: string, imageUrl: string, imageSecureUrl: string, imageData: any) {
+  async updateUserProfileImage(userId: string, imageUrl: string) {
     try {
       const updatedUser = await this.prisma.profile.update({
         where: {
@@ -55,8 +55,6 @@ export default class UserDBService {
         },
         data: {
           imageUrl,
-          imageSecureUrl,
-          imageData,
         },
       });
       if (updatedUser) {
@@ -69,7 +67,7 @@ export default class UserDBService {
     }
   }
 
-  async updateUserWallpaperImage(userId: string, wallpaperUrl: string, wallpaperSecureUrl: string, wallpaperData: any) {
+  async updateUserWallpaperImage(userId: string, wallpaperUrl: string) {
     try {
       const updatedUser = await this.prisma.profile.update({
         where: {
@@ -77,8 +75,6 @@ export default class UserDBService {
         },
         data: {
           wallpaperUrl,
-          wallpaperSecureUrl,
-          wallpaperData,
         },
       });
       if (updatedUser) {


### PR DESCRIPTION
#### What does this PR do?

* Users can update listing to set listing type and purpose

#### Description of Task to be completed?

* [x] resolves #159 

```bash
# Keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved,
# e.g. closes #issueNo
```

#### How can this be manually tested?

After cloning the repo, `cd` into it and do the following:

```bash
# Run the entire application locally
$ lerna exec npm run dev

# Run only the backend api
$ lerna exec --parallel --ignore cribplug npm run dev
```

After services are started, check sample services are running on specified ports (e.g. auth service on port 7700) e.g `localhost:7700/api/v1/auth/test`,

#### Any background context you want to provide?

N/a

#### What are the relevant issues/tickets?

N/a

#### Screenshots (if appropriate)

N/a
